### PR TITLE
Fix bug involving object with stringify overload

### DIFF
--- a/lib/Data/Transform/ExplicitMetadata.pm
+++ b/lib/Data/Transform/ExplicitMetadata.pm
@@ -66,6 +66,7 @@ sub encode {
 
     if (!ref($value)) {
         my $ref_to_value = \$value;
+        my $refaddr     = Scalar::Util::refaddr($ref_to_value);
         my $ref = ref($ref_to_value);
         my $encoded_value = $value;
         # perl 5.8 - ref() with a vstring returns SCALAR
@@ -75,7 +76,7 @@ sub encode {
         ) {
             $encoded_value = encode($ref_to_value, $path_expr, $seen);
             delete $encoded_value->{__refaddr};
-            delete $seen->{$ref_to_value};
+            delete $seen->{$refaddr};
         }
         return $encoded_value;
     }
@@ -89,15 +90,15 @@ sub encode {
 
     my $encoded_value;
 
-    if ($seen->{$value}) {
+    if ($seen->{$refaddr}) {
         $encoded_value = {  __reftype => $reftype,
                             __refaddr => $refaddr,
                             __recursive => 1,
-                            __value => $seen->{$value} };
+                            __value => $seen->{$refaddr} };
         $encoded_value->{__blessed} = $blesstype if $blesstype;
         return $encoded_value;
     }
-    $seen->{$value} = $path_expr;
+    $seen->{$refaddr} = $path_expr;
 
     # Build a new path string for recursive calls
     my $_p = sub {

--- a/t/overloaded_stringify.t
+++ b/t/overloaded_stringify.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use Data::Transform::ExplicitMetadata qw(encode decode);
+
+use Scalar::Util qw(refaddr);
+use Test::More tests => 5;
+
+{
+    package HasStringOverload;
+    use overload '""' => sub { $_[0]->{value} };
+    sub new {
+        my($class, $val) = @_;
+        my %self = ( value => $val );
+        bless \%self, $class;
+    }
+}
+
+my $obj1 = HasStringOverload->new(1);
+my $obj2 = HasStringOverload->new(1);
+
+# Create a list with things that stringify to the same value:
+#   * two elements are the same object instance
+#   * a unique instance
+#   * a raw value
+my $original = [
+    $obj1,
+    $obj1,
+    $obj2,
+    1,
+];
+my $encoded = encode($original);
+ok($encoded, 'encoded');
+
+my $decoded = decode($encoded);
+ok($decoded, 'decoded');
+
+is(refaddr($decoded->[0]), refaddr($decoded->[1]), 'First and second element decode to the same instance');
+isnt(refaddr($decoded->[0]), refaddr($decoded->[2]), 'First and third element are different');
+isnt(refaddr($decoded->[0]), refaddr($decoded->[3]), 'First and fourth element are different');


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=130362

If a data structure includes object with string overloading, and distinct
objects stringify to the same string value, it will incorrectly encode a
structure with a re-used object.

The change involves using object references rather than their string
values when remembering which ones we've already seen.

This fixed #19